### PR TITLE
Support Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.7-dev" # 3.7 development branch
+  - "3.6"
 # command to install dependencies
 install:
   - pip install .

--- a/README.rst
+++ b/README.rst
@@ -26,12 +26,14 @@ Documentation is available at http://pine.readthedocs.io/en/latest/
 Installation
 ============
 
-Under normal circumstances you would just do ``pip install pine``.
+On Python 3.6, ``pip install pine`` will do it.
 
-However, until PyYAML supports Python 3.7 in a released version, one
-extra step is required so we can install PyYAML from GitHub::
+On Python 3.7, there is an additional step required before running the
+same command. Until PyYAML supports Python 3.7 in a released version,
+you will need to install PyYAML from GitHub::
 
     pip install git+https://github.com/yaml/pyyaml.git
+    pip install pine
 
 https://github.com/briancurtin/pine/issues/1 and
 https://github.com/yaml/pyyaml/issues/126 are tracking this issue.
@@ -76,11 +78,6 @@ in ``-o``. It looks like the following::
      "name": "Testing the things",
      "version": "1.0",
      "id": "7155eb"}
-
-Requirements
-============
-
-Pine uses aiohttp on Python 3.7.
 
 Thanks
 ======

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,12 +6,16 @@ A benchmark utility to make requests to a REST API.
 Installation
 ************
 
+On Python 3.6, ``pip install pine`` will do it.
+
 Under normal circumstances you would just do ``pip install pine``.
 
-However, until PyYAML supports Python 3.7 in a released version, one
-extra step is required so we can install PyYAML from GitHub::
+On Python 3.7, there is an additional step required before running the
+same command. Until PyYAML supports Python 3.7 in a released version,
+you will need to install PyYAML from GitHub::
 
     pip install git+https://github.com/yaml/pyyaml.git
+    pip install pine
 
 This will install the ``pine`` script for you to use. If you're installing
 this inside a virtualenv, it'll be in the ``/bin`` folder of that virtualenv.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-aiohttp>=3.0
-certifi>=2018.1.18
 # pyyaml>=3.12 # No released version works with 3.7 yet.
 # See https://github.com/yaml/pyyaml/issues/126
 -e git+https://github.com/yaml/pyyaml.git#egg=pyyaml

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,14 @@ CLASSIFIERS = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
+
 if __name__ == "__main__":
     setup(
         name="pine",
         description="A benchmark utility to make requests to a REST API.",
         license="Apache 2",
         url="http://pine.readthedocs.io/en/latest/",
-        version="0.7.dev0",
+        version="0.7.dev1",
         author=NAME,
         author_email=EMAIL,
         maintainer=NAME,
@@ -38,10 +39,12 @@ if __name__ == "__main__":
         zip_safe=False,
         classifiers=CLASSIFIERS,
         install_requires=[
-            "aiohttp>=3.0",
-            "certifi>=2018.1.18",
-            # Until PyYAML comes out with 3.13 it needs to be installed
-            # separately:
+            "aiohttp >= 3.0",
+            "certifi >= 2018.1.18",
+            "dataclasses >= 0.5; python_version < '3.7'",
+            "pyyaml >= 3.12; python_version == '3.6'",
+            # For Python 3.7, until PyYAML comes out with 3.13 it needs
+            # to be installed manually:
             # pip install git+https://github.com/yaml/pyyaml.git
-            ],
+        ],
     )

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ CLASSIFIERS = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,16 @@
 [tox]
-envlist = py37,pep8
+envlist = py36,py37,pep8
 
 [testenv]
 deps =
-    -rrequirements.txt
     -rtest-requirements.txt
 commands = python -m unittest discover -v tests
+
+[testenv:py37]
+# Getting a working PyYAML on 3.7 requires that we install from GitHub master.
+deps =
+    -rrequirements.txt
+
 
 [testenv:pep8]
 deps = -rtest-requirements.txt


### PR DESCRIPTION
dataclasses are available as a PyPI package for 3.6, so use them instead of expecting people to run this on 3.7 (which is currently only at Beta 3).

This restructures some of the setup.py and requirements.txt handling to get this done right.