### PR TITLE
Include the raw response times in output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,12 +64,14 @@ Pine writes its results in JSON, either to stdout or the path you specified
 in ``-o``. It looks like the following::
 
     {"results": [
-        {"timeouts": 0, "failures": [], "name": "get_all_things",
+        {"times": [1.580882219500005, 1.8884545513215, 1.52546876846],
+         "timeouts": 0, "failures": [], "name": "get_all_things",
          "description": "Get all of the things",
          "mean": 1.668359371049998,
          "median": 1.580882219500005,
          "stdev": 0.0969358463985873},
-        {"timeouts": 0, "failures": [], "name": "get_one_thing",
+        {"times": [0.4894684654656654, 0.508042131499991, 1.054654684684],
+         "timeouts": 0, "failures": [], "name": "get_one_thing",
          "description": "Get one thing",
          "mean": 0.856881387399993,
          "median": 0.508042131499991,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -218,7 +218,8 @@ on each individual test, as follows.
 ::
 
     {"results": [
-        {"timeouts": 0, "failures": [], "name": "get_all_things",
+        {"times": [1.580882219500005, 1.8884545513215, 1.52546876846],
+         "timeouts": 0, "failures": [], "name": "get_all_things",
          "description": "Get all of the things",
          "mean": 1.668359371049998,
          "median": 1.580882219500005,
@@ -236,6 +237,11 @@ on each individual test, as follows.
            For example, if 10/20 responses were ``500 INTERNAL SERVER ERROR``,
            you would still receive statistics about the 10 responses that
            succeeded. How you use that information is up to you.
+
+times
+^^^^^
+
+This is a list of the response times.
 
 timeouts
 ^^^^^^^^

--- a/source/_pine.py
+++ b/source/_pine.py
@@ -50,6 +50,7 @@ class Test(Defaults):
 
 @dataclass
 class Result:
+    times: list
     timeouts: int
     failures: list
     name: str = field(default="")
@@ -100,7 +101,7 @@ async def run_one_test(loop, test):
             except asyncio.TimeoutError:
                 timeouts += 1
 
-    result = Result(timeouts, failures)
+    result = Result(times, timeouts, failures)
     num_times = len(times)
 
     # Need at least two runs to calculate any of this.


### PR DESCRIPTION
We really should be including raw response times instead of only the summary mean/median stuff.